### PR TITLE
Patch for Bug 743113

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
 2015-05-23  willbuntu  <wyznaga@gmail.com>
 
 	* NoteManager.cs: 
-
+		patched Bug 743113 (https://bugzilla.gnome.org/show_bug.cgi?id=743113) - see commit message(s)

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,0 +1,4 @@
+2015-05-23  willbuntu  <wyznaga@gmail.com>
+
+	* NoteManager.cs: 
+

--- a/Tomboy/NoteManager.cs
+++ b/Tomboy/NoteManager.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Threading;
 
 using Mono.Unix;
+using System.Globalization;
 
 namespace Tomboy
 {
@@ -475,13 +476,17 @@ Ciao!");
 		{
 			int new_num = notes.Count;
 			string temp_title;
-
+			
+			// Gets format of day name, date, and time from current user-defind culture
+			string date_format = CultureInfo.CurrentCulture.DateTimeFormat.FullDateTimePattern.ToString ();
+			
 			while (true) {
-                temp_title = String.Format (Catalog.GetString ("Note from {0}"), DateTime.Now.ToString ( Catalog.GetString ("yyyy-MM-dd HH:mm:ss.fff")));
+				// DateTimeFormat string applied here instead of "yyyy-MM-dd HH:mm:ss.fff"
+				temp_title = String.Format (Catalog.GetString ("Note from {0}"), DateTime.Now.ToString ( Catalog.GetString (date_format)));
 				if (Find (temp_title) == null)
 					break;
 			}
-
+			
 			return Create (temp_title);
 		}
 


### PR DESCRIPTION
This fixes the bug in note creation that makes a temporary note title that is somewhat aesthetically unpleasant. Note: this change consists of two commits - I only recently pushed the second one to my own fork, since I noticed the ChangeLog file was not actually functioning as a changelog for me for some reason.
